### PR TITLE
lib/QQBot: Use GB18030 instead of GBK, fix #2

### DIFF
--- a/lib/QQBot.js
+++ b/lib/QQBot.js
@@ -21,17 +21,18 @@ let pminfoCache = new Map();
 
 const base642str = (str) => {
     let s = Buffer.from(str, 'base64').toString('binary');
-    return encoding.convert(s, 'utf8', 'gbk').toString();
+    // TODO: handle [[GB18030#PUA]] properly?
+    return encoding.convert(s, 'utf8', 'gb18030').toString();
 };
 
 const str2base64 = (str) => {
-    let s = encoding.convert(str, 'gbk', 'utf8');
+    let s = encoding.convert(str, 'gb18030', 'utf8');
     return s.toString('base64');
 };
 
 const buf2str = (buffer, left, right) => {
     let temp = buffer.slice(left, right).toString('binary');
-    return encoding.convert(temp, 'utf8', 'gbk').toString();
+    return encoding.convert(temp, 'utf8', 'gb18030').toString();
 };
 
 const replaceEmoji = (str) => str.replace(/\[CQ:emoji,id=(\d*)\]/g, (_, id) => String.fromCodePoint(id));


### PR DESCRIPTION
Character U+34B2 (㒲):
GBK: (not defined)
GB18030: 82 30 82 35 ("UTF" area)
Decode GB18030 as GBK: U+FFFD U+0030 U+FFFD U+0035
Decode GB18030 as GB18030: U+34B2