### PR TITLE
实现上传文件至 Uguu

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -201,6 +201,7 @@ module.exports = {
                    self：將檔案保存在自己的伺服器中
                    vim-cn：將檔案上傳到img.vim-cn.com
                    linx：將檔案上傳到一個 linx（https://github.com/andreimarcu/linx-server）伺服器中
+                   uguu: 將檔案上傳到一個 uguu（https://github.com/nokonoko/Uguu）伺服器中
 
                    另外，如果使用酷Q的話，您需要定期自行清理酷Q的快取！
                  */
@@ -209,6 +210,7 @@ module.exports = {
                 "cachePath": "",                // type為self時有效：快取存放位置
                 "serveUrl": "",                 // type為self時有效：檔案URL的字首，一般需要以斜線結尾
                 "linxApiUrl": "",               // type為linx時有效：linx API位址，一般以斜線結尾
+                "UguuApiUrl": "",               // type為uguu時有效：請使用 /api.php?d=upload-tool 結尾。
                 "sizeLimit": 4096,              // 檔案最大大小，單位KB。0表示不限制。限制僅對Telegram有效。
 
                 // 是否把Telegram的Sticker（webp格式）轉為PNG格式。


### PR DESCRIPTION
目前图片上传缺少一个支持自建且语言为 PHP 的文件空间。这一类脚本一般都可以直接部署到很便宜的虚拟主机上，不需要操作系统虚拟化（不像 Linx）。
我在 GitHub 上挑了一个星星比较多的 [Uguu](https://github.com/nokonoko/Uguu)。这一个 PR 里实现了上传至 Uguu 的过程（其实是魔改上传至 Linx 的代码而来）。